### PR TITLE
John

### DIFF
--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,4 @@
+[ViewState]
+Mode=
+Vid=
+FolderType=Documents

--- a/fileOpenDialog.py
+++ b/fileOpenDialog.py
@@ -11,12 +11,12 @@ class fileOpenDialog(QWidget):
         self.title = 'Open FileA'
         if( self.fileAName != "" ):
             self.title = 'Open FileB'
-        self.left = 10
-        self.top = 10
-        self.width = 640
-        self.height = 480
-        self.openFileNameDialog()
-        self.openFileNameDialog()
+        self.setGeometry(100, 100, 400, 500)
+        
+        
+        
+
+
       
     def openFileNameDialog(self):        
         options = QFileDialog.Options()

--- a/gui_config.py
+++ b/gui_config.py
@@ -42,7 +42,7 @@ ICONS = {
 #converted changes to true with the ICONS are converted once
 #this conversion fails if you attempt to convert everything a second time
 #this only happens when the global scope of the ICONS is saved in a software test
-#but the mainWindow is initialized multiple times.
+#but the mainWindow is initialized multiple times. 
 converted = False
 
 """
@@ -79,15 +79,16 @@ RIGHT_TXT_COL_IDX = 4
 
 
 def convert_icon_dict():
+    
     global ICONS
-
     global converted
     converted = True
-    
     if not ICONS["OBJ_CONVERSION"][0]:
         for icon in ICONS:
             if isinstance(ICONS[icon], str):
                 ICONS[icon] = QIcon(ICONS[icon])
         ICONS["OBJ_CONVERSION"][0] = True
+
         ICONS["OBJ_CONVERSION"] = set(ICONS["OBJ_CONVERSION"])
+
 

--- a/mainWindow.py
+++ b/mainWindow.py
@@ -6,6 +6,7 @@ Main Window
 """
 
 import os.path
+import subprocess
 import sys
 
 from PyQt5.QtWidgets import *
@@ -22,7 +23,7 @@ class mainWindow(QMainWindow, QMessageBox):
     def __init__(self, fileA=0, fileB=0):
         super().__init__()
         self.setWindowTitle("PyMerge")
-        self.setGeometry(1000, 1000, 2000, 1000)
+        self.setGeometry(100, 100, 1000, 800)
         self.table_widget = 0
         self.control_buttons_widget = 0
         layout = QGridLayout()
@@ -65,37 +66,24 @@ class mainWindow(QMainWindow, QMessageBox):
         self.table_widget.clear_table()
         
         fileOpener = fileOpenDialog.fileOpenDialog()
+        fileOpener.openFileNameDialog()
+        if fileOpener.fileAName != "":
+            fileOpener.openFileNameDialog()
 
         fileA = fileOpener.fileAName
         fileB = fileOpener.fileBName
-
-        if not os.path.exists(fileA):
-            print(fileA, "Does not exist")
-        if not os.path.exists(fileB):
-            print(fileB, "Does not exist")
-
-        if not utilities.file_readable(fileA):
-            print(fileA + ": Read permission denied.")
-        if not utilities.file_readable(fileB):
-            print(fileB + ": Read permission denied.")
-
-        if not utilities.file_writable(fileA):
-            print(fileA + ": Write permission denied.")
-        if not utilities.file_writable(fileB):
-            print(fileB + ": Write permission denied.")
-
-        # prompt = QMessageBox.about(self, "Error", "Error Message")
-        fileA = fileOpener.fileAName
-        fileB = fileOpener.fileBName
-
+        
         result = self.fIO.diffFiles(fileA, fileB)
 
         if result == pmEnums.RESULT.GOOD:
             result = self.fIO.getChangeSets(self.fIO.changesA, self.fIO.changesB)
+
         elif result == pmEnums.RESULT.BADFILE:
             QMessageBox.about(self, "Error", "Invalid file type")
 
+            
         self.table_widget.load_table_contents(fileA, fileB)
+        return result
 
     def menuItems(self):
         # ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -105,7 +93,8 @@ class mainWindow(QMainWindow, QMessageBox):
         fileMenu = mainMenu.addMenu('File')
         editMenu = mainMenu.addMenu('Edit')
         viewMenu = mainMenu.addMenu('View')
-
+        helpMenu = mainMenu.addMenu('Help')
+        
         openFileButton = QAction("Open Files", self)
         openFileButton.setShortcut('Ctrl+o')
         openFileButton.triggered.connect(lambda: self.openFile())
@@ -151,17 +140,20 @@ class mainWindow(QMainWindow, QMessageBox):
         HideShowButtons.triggered.connect(lambda: self.hideShowButns())
         viewMenu.addAction(HideShowButtons)
 
-
-        row = QAction("current row", self)
+        HelpButton = QAction("Manual", self)
         #no shortcut
-        row.triggered.connect(self.table_widget.printCurrentRow)
-        viewMenu.addAction(row)
+        HelpButton.triggered.connect(lambda: self.openHelp())
+        helpMenu.addAction(HelpButton)
+        
 
     def hideShowButns(self):        
         if self.control_buttons_widget.isVisible():
             self.control_buttons_widget.hide()
         else:
             self.control_buttons_widget.show()
+
+    def openHelp(self):
+        subprocess.Popen("file1.c",shell=True)
 
 def startMain(fileA=0, fileB=0):
     app = QApplication(sys.argv)

--- a/main_table.py
+++ b/main_table.py
@@ -103,9 +103,10 @@ class MainTable(QWidget):
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
 
         # Convert icon paths from gui_config.py to QIcon objects
-        #gui_cfg.converted ensures test software can run correctly
+        #gui_cgf.converted ensures test software can run correctly
         if gui_cfg.converted == False:
             gui_cfg.convert_icon_dict()
+
         grid.addWidget(self.table)
     
     def set_tbl_fonts_and_colors(self):
@@ -205,7 +206,7 @@ class MainTable(QWidget):
             self.jump_to_line(self.diff_indices[self.curr_diff_idx])
         
         self.select_block()        
-        self.table.repaint()
+        #self.table.repaint()
         return
 
     @pyqtSlot()
@@ -319,16 +320,6 @@ class MainTable(QWidget):
         
         return
 
-    @pyqtSlot()
-    def printCurrentRow(self):
-        """
-        merge the whole right selection into the right
-        """
-        print("current Row")
-        print(self.table.currentRow())
-        return 0
-
-    
 
     def jump_to_line(self, line_num, col=0):
         self.table.clearSelection()
@@ -336,9 +327,9 @@ class MainTable(QWidget):
             self.table.item(line_num-1, col), QtWidgets.QAbstractItemView.PositionAtTop
         )
         
-        self.table.scrollToItem(
-            self.table.selectRow(line_num), QtWidgets.QAbstractItemView.PositionAtTop
-        )
+        # self.table.scrollToItem(
+        #     self.table.selectRow(line_num), QtWidgets.QAbstractItemView.PositionAtTop
+        # )
 
     
         
@@ -505,6 +496,7 @@ class MainTable(QWidget):
         self.jump_to_line(77)
 
     def select_block(self, n=-1):
+
         if n != -1:
             j = 0
             for i in self.diff_indices:
@@ -519,6 +511,8 @@ class MainTable(QWidget):
         self.selected_block[1] = self.diff_index_block_end[self.curr_diff_idx]
         for n in range(self.diff_indices[self.curr_diff_idx], self.diff_index_block_end[self.curr_diff_idx]):
             self.table.selectRow(n)
+            
+            
         
         self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
 

--- a/table_row.py
+++ b/table_row.py
@@ -157,6 +157,7 @@ class Row(QtCore.QObject):
         self.left_button.setEnabled(False)
                 
         # Table isn't gonna repaint itself. Gotta show users the changes we just made.
+        self.table.clearSelection()
         self.table.repaint()
 
     @pyqtSlot()
@@ -192,6 +193,7 @@ class Row(QtCore.QObject):
         self.left_button.setEnabled(False)
         self.right_button.setEnabled(False)        
         # Table isn't gonna repaint itself. Gotta show users the changes we just made.
+        self.table.clearSelection()
         self.table.repaint()
 
     def set_row_state(self):

--- a/table_row.py
+++ b/table_row.py
@@ -94,7 +94,7 @@ class Row(QtCore.QObject):
         #self.table.item(self.row_num, gui_cfg.RIGHT_TXT_COL_IDX).setFlags(QtCore.Qt.ItemIsEditable)
         self.table.item(self.row_num, gui_cfg.RIGHT_TXT_COL_IDX).setBackground(
             background
-        )
+        )        
         self.right_background_color = background
         if buttons:
             self.add_row_merge_buttons()

--- a/undo_redo.py
+++ b/undo_redo.py
@@ -70,10 +70,15 @@ class UndoRedoAction(object):
         Set the current state of the row object to what was recorded in the instance variables
         :return: No return value
         """
-        # Copy the copied attribute dictionary over to the object reference
+        # Copy the copied attribute dictionary over to the object reference        
         for key in self.obj_ref.__dict__:
-            self.obj_ref.right_button.setEnabled(True)
-            self.obj_ref.left_button.setEnabled(True)
+            if self.obj_ref.right_button.isEnabled() == True:            
+                self.obj_ref.right_button.setEnabled(False)
+                self.obj_ref.left_button.setEnabled(False)
+            else:
+                self.obj_ref.right_button.setEnabled(True)
+                self.obj_ref.left_button.setEnabled(True)
+
             try:
                 self.obj_ref.__dict__[key] = self.obj_copy[key]
             except KeyError:


### PR DESCRIPTION
File Open dialogs open in a normal position, not all scattered like they were. If cancel is hit in the first box, the second box does not open.

Redoing did not disable buttons if a merge was redone. It now does so. So undo/redo/undo doest not leave row merge buttons enabled. 

Help file menu item added, and can open the help doc we create with the users prefered file viewer. (outside the application, so likely a pdf viewer or whatever)

