### PR TITLE
read only file warning fix

### DIFF
--- a/file_io.py
+++ b/file_io.py
@@ -35,6 +35,9 @@ import diff_resolution
 import pymerge_enums
 import utilities
 
+import os
+import os.path
+from PyQt5.QtWidgets import QApplication, QWidget, QPushButton, QMessageBox
 
 class FileIO(object):
     def __init__(self):
@@ -57,19 +60,25 @@ class FileIO(object):
             print("\n[-] Unacceptable file type:", file_b_base_name, "\n")
             return pymerge_enums.RESULT.BADFILE
 
-        file_a = open(file_a, "r")
-        file_b = open(file_b, "r")
+        file_a_open = open(file_a, "r")
+        file_b_open = open(file_b, "r")
 
         result = diff_resolution.diff_set(
-            file_a, file_b, file_a, file_b, self.changes_a, self.changes_b
+            file_a_open, file_b_open, file_a_open, file_b_open, self.changes_a, self.changes_b
         )
 
-        file_a.close()
-        file_b.close()
+        file_a_open.close()
+        file_b_open.close()
 
         if result == pymerge_enums.RESULT.GOOD:
+            if not utilities.file_writable(file_a):            
+                return pymerge_enums.RESULT.READONLYA
+
+            if not utilities.file_writable(file_b):
+                return pymerge_enums.RESULT.READONLYB
+
             return pymerge_enums.RESULT.GOOD
-        return pymerge_enums.RESULT.NOTIMPL
+
 
     def get_change_sets(self, file_a, file_b):
         file_a = self.changes_a

--- a/file_open_dialog.py
+++ b/file_open_dialog.py
@@ -32,7 +32,7 @@ class FileOpenDialog(QWidget):
         self.title = 'Open File'
         self.setGeometry(100, 100, 400, 500)
               
-    def open_file_name_dialog(self):
+    def open_file_name_dialog(self, openWhat):
         options = QFileDialog.Options()
-        self.file_name, _ = QFileDialog.getOpenFileName(self, "Open File A", "", "", options=options)
+        self.file_name, _ = QFileDialog.getOpenFileName(self, "Open " + openWhat, "", "", options=options)
 

--- a/main_table.py
+++ b/main_table.py
@@ -33,6 +33,9 @@ from PyQt5.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QGridLayout,
+    QApplication,
+    QPushButton,
+    QMessageBox
 )
 
 import file_io
@@ -42,7 +45,7 @@ import merge_finalizer
 import pymerge_enums
 import table_row
 import undo_redo
-
+import utilities
 
 class MainTable(QWidget):
     def __init__(self, change_set_a, change_set_b):
@@ -210,6 +213,11 @@ class MainTable(QWidget):
             else:
                 self.clear_table()
                 fileB = path
+
+                if not utilities.file_writable(self.file_dropped):            
+                    QMessageBox.about(self, "Warning ", os.path.basename(self.file_dropped) + " is read only")
+                if not utilities.file_writable(fileB):            
+                    QMessageBox.about(self, "Warning ", os.path.basename(fileB) + " is read only")
 
                 # I use a local instance of fileIO to generate changesets, since
                 # main_table can't access the main window instance of fileIO

--- a/main_window.py
+++ b/main_window.py
@@ -69,6 +69,12 @@ class MainWindow(QMainWindow, QMessageBox):
 
         layout.addWidget(self.table_widget, 1, 0)
 
+        if result == pymerge_enums.RESULT.READONLYA:
+            QMessageBox.about(self, "Warning ", os.path.basename(fileA) + " is read only")
+
+        elif result == pymerge_enums.RESULT.READONLYB:
+            QMessageBox.about(self, "Warning ", os.path.basename(fileB) + " is read only")
+        
         # load table with fileA and B if present from command line
         if fileA != 0 and fileB != 0:
             self.table_widget.load_table_contents(fileA, fileB)  # Left list arguments for now
@@ -94,19 +100,12 @@ class MainWindow(QMainWindow, QMessageBox):
         file_opener_a = file_open_dialog.FileOpenDialog()
         file_opener_b = file_open_dialog.FileOpenDialog()
         
-        file_opener_a.open_file_name_dialog()
+        file_opener_a.open_file_name_dialog("file A")
         file_a = file_opener_a.file_name
         
         if file_a != "":
-            file_opener_b.open_file_name_dialog()
+            file_opener_b.open_file_name_dialog("file B")
         file_b = file_opener_b.file_name
-
-        if not utilities.file_writable(file_a):
-            QMessageBox.about(self, "Error", os.path.basename(file_a) + " is not writable")
-            return
-        if not utilities.file_writable(file_b):
-            QMessageBox.about(self, "Error", os.path.basename(file_b) + " is not writable")
-            return
         
         result = self.fIO.diff_files(file_a, file_b)
 
@@ -115,6 +114,13 @@ class MainWindow(QMainWindow, QMessageBox):
 
         elif result == pymerge_enums.RESULT.BADFILE:
             QMessageBox.about(self, "Error", "Invalid file type")
+
+        elif result == pymerge_enums.RESULT.READONLYA:
+            QMessageBox.about(self, "Warning ", os.path.basename(file_a) + " is read only")
+
+        elif result == pymerge_enums.RESULT.READONLYB:
+            QMessageBox.about(self, "Warning ", os.path.basename(file_b) + " is read only")
+
 
         self.table_widget.load_table_contents(file_a, file_b)
         return result

--- a/pymerge_enums.py
+++ b/pymerge_enums.py
@@ -35,6 +35,8 @@ class RESULT(Enum):
     NOTIMPL = 2  # not implemented
     BADFILE = 3  # file mismatch
     EMPTYFILE = 4
+    READONLYA = 5
+    READONLYB = 6
 
 
 class ATTRIB(Enum):


### PR DESCRIPTION
if a file is read only, it should prompt, not prompt then escape. The user may know its read only and just want to view them or will change the file to read/write after he sees its an issue. FileIO returns "read only" enum if the file is read only and the client function needs to handle this case. Because the client is what scope a display message must be in.